### PR TITLE
bugfix: Trainer - pass gpu indices, config parse error when passing lists. 

### DIFF
--- a/seg_lapa/config/trainer/trainer.yaml
+++ b/seg_lapa/config/trainer/trainer.yaml
@@ -1,6 +1,6 @@
 # @package _group_
 name: trainer
-gpus: "0"
+gpus: [0]
 overfit_batches: 0.0
 distributed_backend: "ddp"
 precision: 16

--- a/seg_lapa/config_parse/conf_utils.py
+++ b/seg_lapa/config_parse/conf_utils.py
@@ -1,7 +1,7 @@
 import dataclasses
 from typing import Optional, Sequence, Dict
 
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 
 def asdict_filtered(obj, remove_keys: Optional[Sequence[str]] = None) -> Dict:
@@ -51,7 +51,8 @@ def validate_config_group_generic(
         dataclass_config = mapping_names_dataclass[cfg_group.name]
 
         # Init the dataclass using hydra config
-        dataconf = dataclass_config(**cfg_group)
+        cfg_asdict = OmegaConf.to_container(cfg_group, resolve=True)
+        dataconf = dataclass_config(**cfg_asdict)
 
     except KeyError:
         if config_category is None:

--- a/seg_lapa/config_parse/trainer_conf.py
+++ b/seg_lapa/config_parse/trainer_conf.py
@@ -19,7 +19,7 @@ class TrainerConf(ABC):
 
 @dataclass(frozen=True)
 class TrainerConfig(TrainerConf):
-    gpus: Union[int, str, List[int]]
+    gpus: Union[str, List[int]]
     overfit_batches: Union[int, float]
     distributed_backend: Optional[str]
     precision: int


### PR DESCRIPTION
The trainer.gpus, if given an int, indicates the number of gpus to use, instead of the ID of gpu to use. Corrected this by casting to str or list of ints in pydantic. 

When passing lists to Hydra, the config contains the list as an OmegaConf config objects. It looks similar to python dicts and list, but it really different. This causes errors with Pydantic when trying to resolve lists.
Hence, we convert to primitive containers before passing to pydantic for validation.