### PR TITLE
bugfix: pass number of gpus to Trainer instead of gpu ids. 

### DIFF
--- a/seg_lapa/config/trainer/trainer.yaml
+++ b/seg_lapa/config/trainer/trainer.yaml
@@ -1,6 +1,7 @@
 # @package _group_
 name: trainer
-gpus: [0]
+
+gpus: 1  # Denotes the number of gpus to use. Set CUDA_VISIBLE_DEVICES env var to control which gpus are used.
 overfit_batches: 0.0
 distributed_backend: "ddp"
 precision: 16

--- a/seg_lapa/config_parse/trainer_conf.py
+++ b/seg_lapa/config_parse/trainer_conf.py
@@ -19,7 +19,7 @@ class TrainerConf(ABC):
 
 @dataclass(frozen=True)
 class TrainerConfig(TrainerConf):
-    gpus: Union[str, List[int]]
+    gpus: int
     overfit_batches: Union[int, float]
     distributed_backend: Optional[str]
     precision: int


### PR DESCRIPTION
See: https://github.com/PyTorchLightning/pytorch-lightning/issues/5264

We now pass in number of gpus to use to PL.Trainer. Set CUDA_VISIBLE_DEVICES to set the gpu ids to use.